### PR TITLE
Add default preset/fallback config

### DIFF
--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -8,12 +8,15 @@ import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import ConsoleApiContext from "@foxglove/studio-base/context/ConsoleApiContext";
+import LayoutManagerContext from "@foxglove/studio-base/context/LayoutManagerContext";
 import PanelCatalogContext, {
   PanelCatalog,
   PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
+import { ILayoutStorage, Layout, LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
+import LayoutManager from "@foxglove/studio-base/services/LayoutManager/LayoutManager";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import Workspace from "./Workspace";
@@ -54,6 +57,45 @@ class MockPanelCatalog implements PanelCatalog {
   }
 }
 
+class MockLayoutStorage implements ILayoutStorage {
+  private storage: { [namespace: string]: { [id: LayoutID]: Layout } };
+
+  public constructor() {
+    this.storage = {};
+  }
+
+  public async list(namespace: string): Promise<readonly Layout[]> {
+    return Object.values(this.storage[namespace] ?? {});
+  }
+  public async get(namespace: string, id: LayoutID): Promise<Layout | undefined> {
+    return this.storage[namespace]?.[id];
+  }
+  public async put(namespace: string, layout: Layout): Promise<Layout> {
+    const namespaceStorage = this.storage[namespace] ?? {};
+    namespaceStorage[layout.id] = layout;
+    this.storage[namespace] = namespaceStorage;
+
+    return layout;
+  }
+  public async delete(namespace: string, id: LayoutID): Promise<void> {
+    delete this.storage[namespace]?.[id];
+  }
+
+  public async importLayouts(params: {
+    fromNamespace: string;
+    toNamespace: string;
+  }): Promise<void> {
+    const fromNamespaceStorage = this.storage[params.fromNamespace] ?? {};
+    const toNamespaceStorage = this.storage[params.toNamespace] ?? {};
+
+    const newToNamespaceStorage = {
+      ...toNamespaceStorage,
+      ...JSON.parse(JSON.stringify(fromNamespaceStorage) ?? "{}"),
+    };
+    this.storage[params.toNamespace] = newToNamespaceStorage;
+  }
+}
+
 export function Basic(): JSX.Element {
   const providers = [
     /* eslint-disable react/jsx-key */
@@ -62,6 +104,9 @@ export function Basic(): JSX.Element {
     <EventsProvider />,
     <PanelCatalogContext.Provider value={new MockPanelCatalog()} />,
     <MockCurrentLayoutProvider initialState={{ layout: "Fake" }} />,
+    <LayoutManagerContext.Provider
+      value={new LayoutManager({ local: new MockLayoutStorage(), remote: undefined })}
+    />,
     /* eslint-enable react/jsx-key */
   ];
   return (

--- a/packages/studio-base/src/util/appURLState.test.ts
+++ b/packages/studio-base/src/util/appURLState.test.ts
@@ -49,6 +49,12 @@ describe("app state url parser", () => {
       });
     });
 
+    it("parses urls with only a layoutUrl", () => {
+      const url = urlBuilder();
+      url.searchParams.append("layoutUrl", "http://localhost/layout.json");
+      expect(parseAppURLState(url)?.layoutUrl).toBe("http://localhost/layout.json");
+    });
+
     it("parses data platform state urls", () => {
       const now: Time = { sec: new Date().getTime(), nsec: 0 };
       const time = toRFC3339String({ sec: now.sec + 500, nsec: 0 });
@@ -84,10 +90,11 @@ describe("app state url parser", () => {
 describe("app state encoding", () => {
   const baseURL = () => new URL("http://example.com");
 
-  it("encodes rosbag urls", () => {
+  it("encodes rosbag urls and layout urls", () => {
     expect(
       updateAppURLState(baseURL(), {
         layoutId: "123" as LayoutID,
+        layoutUrl: "http://localhost/layout.json",
         time: undefined,
         ds: "ros1-remote-bagfile",
         dsParams: {
@@ -95,7 +102,7 @@ describe("app state encoding", () => {
         },
       }).href,
     ).toEqual(
-      "http://example.com/?ds=ros1-remote-bagfile&ds.url=http%3A%2F%2Ffoxglove.dev%2Ftest.bag&layoutId=123",
+      "http://example.com/?ds=ros1-remote-bagfile&ds.url=http%3A%2F%2Ffoxglove.dev%2Ftest.bag&layoutId=123&layoutUrl=http%3A%2F%2Flocalhost%2Flayout.json",
     );
   });
 

--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -11,6 +11,7 @@ export type AppURLState = {
   ds?: string;
   dsParams?: Record<string, string>;
   layoutId?: LayoutID;
+  layoutUrl?: string;
   time?: Time;
 };
 
@@ -29,6 +30,14 @@ export function updateAppURLState(url: URL, urlState: AppURLState): URL {
       newURL.searchParams.set("layoutId", urlState.layoutId);
     } else {
       newURL.searchParams.delete("layoutId");
+    }
+  }
+
+  if ("layoutUrl" in urlState) {
+    if (urlState.layoutUrl) {
+      newURL.searchParams.set("layoutUrl", urlState.layoutUrl);
+    } else {
+      newURL.searchParams.delete("layoutUrl");
     }
   }
 
@@ -75,6 +84,7 @@ export function updateAppURLState(url: URL, urlState: AppURLState): URL {
 export function parseAppURLState(url: URL): AppURLState | undefined {
   const ds = url.searchParams.get("ds") ?? undefined;
   const layoutId = url.searchParams.get("layoutId");
+  const layoutUrl = url.searchParams.get("layoutUrl");
   const timeString = url.searchParams.get("time");
   const time = timeString == undefined ? undefined : fromRFC3339String(timeString);
   const dsParams: Record<string, string> = {};
@@ -88,6 +98,7 @@ export function parseAppURLState(url: URL): AppURLState | undefined {
   const state: AppURLState = omitBy(
     {
       layoutId: layoutId ? (layoutId as LayoutID) : undefined,
+      layoutUrl: layoutUrl ? layoutUrl : undefined,
       time,
       ds,
       dsParams: isEmpty(dsParams) ? undefined : dsParams,


### PR DESCRIPTION
Adds a default config which is under the same root url than the website itself.
This allows to put a `config.json` file under `/web/.webpack/config.json` and it is loaded automatically if no other file is provided via URL.
Works independent of web server used.
